### PR TITLE
Ttl on map entries

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/consul/ConsulClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/ConsulClusterManager.java
@@ -57,7 +57,6 @@ public class ConsulClusterManager implements ClusterManager {
         Objects.requireNonNull(options, "Consul client options can't be null");
         this.consulClientOptions = options;
         this.nodeId = UUID.randomUUID().toString();
-
     }
 
     public ConsulClusterManager() {

--- a/src/main/java/io/vertx/spi/cluster/consul/ConsulClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/ConsulClusterManager.java
@@ -152,7 +152,7 @@ public class ConsulClusterManager implements ClusterManager {
         log.trace("'{}' is trying to leave the cluster.", nodeId);
         if (active) {
             active = false;
-
+            // TODO: implement this!
         } else {
             log.warn("'{}' is NOT active.", nodeId);
             resultFuture.complete();

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/AliceService.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/AliceService.java
@@ -37,7 +37,7 @@ public class AliceService {
 
         // 4. vertx
         VertxOptions vertxOptions = new VertxOptions();
-        vertxOptions.setEventLoopPoolSize(1);
+
         vertxOptions.setClusterManager(consulClusterManager);
 
         Vertx.clusteredVertx(vertxOptions, res -> {
@@ -69,7 +69,7 @@ public class AliceService {
                 vertx.sharedData().getAsyncMap("custom", result -> {
                     if (result.succeeded()) {
                         AsyncMap<Object, Object> asyncMap = result.result();
-                        asyncMap.putIfAbsent("Roman", "Lev", 20, completionHandler -> {
+                        asyncMap.put("Roman", "Lev", 20, completionHandler -> {
 
                         });
                     } else {

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/AliceService.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/AliceService.java
@@ -9,6 +9,7 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.spi.cluster.consul.ConsulClusterManager;
@@ -16,14 +17,14 @@ import io.vertx.spi.cluster.consul.impl.AvailablePortFinder;
 
 import java.net.UnknownHostException;
 
-public class ServiceA {
+public class AliceService {
 
     // slf4j
     static {
         System.setProperty("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.SLF4JLogDelegateFactory");
     }
 
-    private static final Logger log = LoggerFactory.getLogger(ServiceA.class);
+    private static final Logger log = LoggerFactory.getLogger(AliceService.class);
     private static Vertx vertx;
 
 
@@ -65,6 +66,17 @@ public class ServiceA {
 
             router.route("/serviceA*").handler(BodyHandler.create());
             router.get("/serviceA").handler(event -> {
+                vertx.sharedData().getAsyncMap("custom", result -> {
+                    if (result.succeeded()) {
+                        AsyncMap<Object, Object> asyncMap = result.result();
+                        asyncMap.putIfAbsent("Roman", "Lev", 20, completionHandler -> {
+
+                        });
+                    } else {
+                        log.error("Can't get custom map due to: {}", result.cause().toString());
+                    }
+                });
+
                 vertx.eventBus().send("vertx-consul", "ping", replyHandler -> {
                     if (replyHandler.succeeded()) {
                         log.trace(replyHandler.result().body().toString());

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/BobService.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/BobService.java
@@ -14,14 +14,14 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 
-public class ServiceB {
+public class BobService {
 
     // slf4j
     static {
         System.setProperty("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.SLF4JLogDelegateFactory");
     }
 
-    private static final Logger log = LoggerFactory.getLogger(ServiceB.class);
+    private static final Logger log = LoggerFactory.getLogger(BobService.class);
     private static Vertx vertx;
 
 

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/BobService.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/BobService.java
@@ -44,7 +44,6 @@ public class BobService {
 
         // 4. vertx
         VertxOptions vertxOptions = new VertxOptions();
-        vertxOptions.setEventLoopPoolSize(1);
         vertxOptions.setClusterManager(consulClusterManager);
 
         Vertx.clusteredVertx(vertxOptions, res -> {

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterA.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterA.java
@@ -1,4 +1,4 @@
-package io.vertx.spi.cluster.consul.examples;
+package io.vertx.spi.cluster.consul.examples.testing;
 
 import io.vertx.core.*;
 import io.vertx.core.logging.Logger;

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterA.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterA.java
@@ -46,7 +46,7 @@ public class ConsulSessionTesterA {
 
         ConsulSessionTesterA tester = new ConsulSessionTesterA();
 
-        tester.vertx.setPeriodic(5000, event -> {
+        tester.vertx.setPeriodic(15000, event -> {
             tester.consulClient.localChecks(localChecks -> {
                 List<Check> failedCheck = localChecks.result().stream().filter(check -> check.getStatus() == CheckStatus.CRITICAL).collect(Collectors.toList());
                 failedCheck.forEach(check -> {

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterB.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterB.java
@@ -1,4 +1,4 @@
-package io.vertx.spi.cluster.consul.examples;
+package io.vertx.spi.cluster.consul.examples.testing;
 
 import io.vertx.core.*;
 import io.vertx.core.logging.Logger;

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterB.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTesterB.java
@@ -46,7 +46,7 @@ public class ConsulSessionTesterB {
 
         ConsulSessionTesterB tester = new ConsulSessionTesterB();
 
-        tester.vertx.setPeriodic(5000, event -> {
+        tester.vertx.setPeriodic(15000, event -> {
             tester.consulClient.localChecks(localChecks -> {
                 List<Check> failedCheck = localChecks.result().stream().filter(check -> check.getStatus() == CheckStatus.CRITICAL).collect(Collectors.toList());
                 failedCheck.forEach(check -> {

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTtlTesterA.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTtlTesterA.java
@@ -1,0 +1,69 @@
+package io.vertx.spi.cluster.consul.examples.testing;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.consul.ConsulClient;
+import io.vertx.ext.consul.KeyValueOptions;
+import io.vertx.ext.consul.SessionBehavior;
+import io.vertx.ext.consul.SessionOptions;
+
+public class ConsulSessionTtlTesterA {
+    // slf4j
+    static {
+        System.setProperty("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.SLF4JLogDelegateFactory");
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(ConsulSessionTtlTesterA.class);
+
+    private static Vertx vertx = Vertx.vertx();
+    private static ConsulClient consulClient = ConsulClient.create(vertx);
+
+    public static void main(String[] args) {
+        registerSession()
+                .compose(ConsulSessionTtlTesterA::registerKv)
+                .compose(aVoid -> {
+                    consulClient.getValue("Roman", resultHandler -> {
+                        if (resultHandler.succeeded()) {
+                            log.trace(resultHandler.result().getValue());
+                        }
+                    });
+                    return Future.succeededFuture();
+                });
+    }
+
+    private static Future<String> registerSession() {
+        Future<String> future = Future.future();
+        SessionOptions sessionOptions = new SessionOptions()
+                .setTtl(30)
+                .setName("testSession")
+
+                .setBehavior(SessionBehavior.DELETE);
+
+        consulClient.createSessionWithOptions(sessionOptions, idHandler -> {
+            if (idHandler.succeeded()) {
+                log.trace(idHandler.result());
+                future.complete(idHandler.result());
+            } else {
+                future.fail(idHandler.cause());
+            }
+
+        });
+        return future;
+    }
+
+    private static Future<Void> registerKv(String sessionId) {
+        Future<Void> future = Future.future();
+        consulClient.putValueWithOptions("Roman", "Lev", new KeyValueOptions()
+                .setAcquireSession(sessionId), event -> {
+            if (event.succeeded()) {
+                log.trace("entry has been registered.");
+                future.complete();
+            } else {
+                future.fail(event.cause());
+            }
+        });
+        return future;
+    }
+}

--- a/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTtlTesterB.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/examples/testing/ConsulSessionTtlTesterB.java
@@ -1,0 +1,38 @@
+package io.vertx.spi.cluster.consul.examples.testing;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.consul.ConsulClient;
+
+public class ConsulSessionTtlTesterB {
+    // slf4j
+    static {
+        System.setProperty("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.SLF4JLogDelegateFactory");
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(ConsulSessionTtlTesterB.class);
+
+    private static Vertx vertx = Vertx.vertx();
+    private static ConsulClient consulClient = ConsulClient.create(vertx);
+
+    public static void main(String[] args) {
+        consulClient.getValue("Roman", event -> {
+            if (event.succeeded()) {
+                log.trace("got by Roman :'{}'", event.result().getValue());
+                log.trace("session id Roman :'{}'", event.result().getSession());
+
+                // KeyValueOptions keyValueOptions = new KeyValueOptions().setAcquireSession(event.result().getSession().set);
+
+                consulClient.putValue("Roman", "Updated", resultHandler -> {
+                    if (resultHandler.succeeded()) {
+                        log.trace("updated");
+                    }
+                });
+
+            }
+        });
+    }
+
+
+}

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMap.java
@@ -31,11 +31,7 @@ public class ConsulAsyncMap<K, V> extends ConsulMap<K, V> implements AsyncMap<K,
 
     private final Vertx vertx;
 
-    public ConsulAsyncMap(String name,
-                          Vertx vertx,
-                          ConsulClient consulClient,
-                          ConsulClientOptions consulClientOptions,
-                          String sessionId) {
+    public ConsulAsyncMap(String name, Vertx vertx, ConsulClient consulClient, ConsulClientOptions consulClientOptions, String sessionId) {
         super(consulClient, name, sessionId);
         this.vertx = vertx;
         printOutAsyncMap();

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMultiMap.java
@@ -170,7 +170,7 @@ public class ConsulAsyncMultiMap<K, V> extends ConsulMap<K, V> implements AsyncM
 
     // helper method used to print out periodically the async consul map.
     private void printOutAsyncMultiMap() {
-        vertx.setPeriodic(10000, event -> consulClient.getValues(name, futureValues -> {
+        vertx.setPeriodic(15000, event -> consulClient.getValues(name, futureValues -> {
             if (futureValues.succeeded()) {
                 if (Objects.nonNull(futureValues.result()) && Objects.nonNull(futureValues.result().getList())) {
                     Map<String, String> asyncMap = futureValues.result().getList().stream().collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMultiMap.java
@@ -63,7 +63,7 @@ public class ConsulAsyncMultiMap<K, V> extends ConsulMap<K, V> implements AsyncM
                     } else {
                         aSet.add(v);
                         try {
-                            consulClient.putValueWithOptions(consulKey, encode(aSet), kvOptions, resultHandler -> {
+                            consulClient.putValueWithOptions(consulKey, encode(aSet), defaultKvOptions, resultHandler -> {
                                 if (resultHandler.succeeded()) {
                                     log.trace("KV: '{}'->'{}' has been added to Consul Async Multimap: '{}'.", consulKey, v.toString(), name);
                                     future.complete();

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulAsyncMultiMap.java
@@ -36,11 +36,7 @@ public class ConsulAsyncMultiMap<K, V> extends ConsulMap<K, V> implements AsyncM
     private final Vertx vertx;
     private final ConsulClientOptions consulClientOptions;
 
-    public ConsulAsyncMultiMap(String name,
-                               Vertx vertx,
-                               ConsulClient consulClient,
-                               ConsulClientOptions consulClientOptions,
-                               String sessionId) {
+    public ConsulAsyncMultiMap(String name, Vertx vertx, ConsulClient consulClient, ConsulClientOptions consulClientOptions, String sessionId) {
         super(consulClient, name, sessionId);
         this.vertx = vertx;
         this.consulClientOptions = consulClientOptions;

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulMap.java
@@ -110,22 +110,6 @@ abstract class ConsulMap<K, V> {
         return future;
     }
 
-    Future<Set<K>> keys() {
-        log.trace("Fetching all keys from: {}", this.name);
-        Future<Set<K>> future = Future.future();
-        consulClient.getKeys(this.name, resultHandler -> {
-            if (resultHandler.succeeded()) {
-                log.trace("Ks: '{}' of: '{}'", resultHandler.result(), this.name);
-                // FIXME
-                future.complete(new HashSet<>((List<K>) resultHandler.result()));
-            } else {
-                log.error("Error occurred while fetching all the keys from: '{}' due to: '{}'", this.name, resultHandler.cause().toString());
-                future.fail(resultHandler.cause());
-            }
-        });
-        return future;
-    }
-
     /**
      * Verifies whether value is not null.
      */

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulMap.java
@@ -23,34 +23,29 @@ abstract class ConsulMap<K, V> {
     final ConsulClient consulClient;
     final String name;
     final String sessionId;
-    final KeyValueOptions kvOptions;
+    final KeyValueOptions defaultKvOptions;
 
-    private final EnumSet<ClusterManagerMaps> clusterManagerMaps = EnumSet.of(ClusterManagerMaps.VERTX_HA_INFO,ClusterManagerMaps.VERTX_SUBS);
+    private final EnumSet<ClusterManagerMaps> clusterManagerMaps = EnumSet.of(ClusterManagerMaps.VERTX_HA_INFO, ClusterManagerMaps.VERTX_SUBS);
 
     ConsulMap(ConsulClient consulClient, String name, String sessionId) {
         this.consulClient = consulClient;
         this.name = name;
         this.sessionId = sessionId;
-        this.kvOptions = clusterManagerMaps.contains(ClusterManagerMaps.fromString(name)) ? new KeyValueOptions().setAcquireSession(sessionId) : null;
+        this.defaultKvOptions = clusterManagerMaps.contains(ClusterManagerMaps.fromString(name)) ? new KeyValueOptions().setAcquireSession(sessionId) : null;
     }
 
     Future<Void> putValue(K k, V v) {
         log.trace("'{}' - trying to put KV: '{}'->'{}' CKV.", name, k, v);
         return assertKeyAndValueAreNotNull(k, v)
                 .compose(aVoid -> encodeInFuture(v))
-                .compose(value -> {
-                    Future<Void> future = Future.future();
-                    consulClient.putValueWithOptions(getConsulKey(name, k), value, kvOptions, resultHandler -> {
-                        if (resultHandler.succeeded()) {
-                            log.trace("'{}'- KV: '{}'->'{}' has been put to CKV.", name, k.toString(), v.toString());
-                            future.complete();
-                        } else {
-                            log.error("'{}' - Can't put KV: '{}'->'{}' to CKV due to: '{}'", name, k.toString(), v.toString(), future.cause().toString());
-                            future.fail(resultHandler.cause());
-                        }
-                    });
-                    return future;
-                });
+                .compose(value -> putValueWithOptions(getConsulKey(name, k), value, defaultKvOptions));
+    }
+
+    Future<Void> putValue(K k, V v, KeyValueOptions keyValueOptions) {
+        log.trace("'{}' - trying to put KV: '{}'->'{}' CKV.", name, k, v);
+        return assertKeyAndValueAreNotNull(k, v)
+                .compose(aVoid -> encodeInFuture(v))
+                .compose(value -> putValueWithOptions(getConsulKey(name, k), value, keyValueOptions));
     }
 
     Future<V> removeValue(K k) {
@@ -131,7 +126,6 @@ abstract class ConsulMap<K, V> {
         return future;
     }
 
-
     /**
      * Verifies whether value is not null.
      */
@@ -159,5 +153,19 @@ abstract class ConsulMap<K, V> {
 
     String getConsulKey(String name, K k) {
         return name + "/" + k.toString();
+    }
+
+    private Future<Void> putValueWithOptions(String key, String value, KeyValueOptions keyValueOptions) {
+        Future<Void> future = Future.future();
+        consulClient.putValueWithOptions(key, value, keyValueOptions, resultHandler -> {
+            if (resultHandler.succeeded()) {
+                log.trace("'{}'- KV: '{}'->'{}' has been put to CKV.", name, key, value);
+                future.complete();
+            } else {
+                log.error("'{}' - Can't put KV: '{}'->'{}' to CKV due to: '{}'", name, key, value, future.cause().toString());
+                future.fail(resultHandler.cause());
+            }
+        });
+        return future;
     }
 }

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulMap.java
@@ -22,8 +22,9 @@ abstract class ConsulMap<K, V> {
 
     final ConsulClient consulClient;
     final String name;
-    final String sessionId;
     final KeyValueOptions defaultKvOptions;
+
+    private final String sessionId;
 
     private final EnumSet<ClusterManagerMaps> clusterManagerMaps = EnumSet.of(ClusterManagerMaps.VERTX_HA_INFO, ClusterManagerMaps.VERTX_SUBS);
 

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulSyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/ConsulSyncMap.java
@@ -146,6 +146,6 @@ public final class ConsulSyncMap<K, V> extends ConsulMap<K, V> implements Map<K,
     // just a dummy helper method [it's gonna get removed] to print out every 5 sec the data that resides within the internal cache.
     // TODO : removed it when consul cluster manager is more or less stable.
     private void printCache() {
-        vertx.setPeriodic(10000, handler -> log.trace("Internal HaInfo (Sync) Map: '{}'", Json.encodePrettily(cache)));
+        vertx.setPeriodic(15000, handler -> log.trace("Internal HaInfo (Sync) Map: '{}'", Json.encodePrettily(cache)));
     }
 }

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/NodeManager.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/NodeManager.java
@@ -446,6 +446,6 @@ public class NodeManager {
     }
 
     private void printLocalNodeMap() {
-        vertx.setPeriodic(10000, handler -> log.trace("Nodes are: '{}'", Json.encodePrettily(nodes)));
+        vertx.setPeriodic(15000, handler -> log.trace("Nodes are: '{}'", Json.encodePrettily(nodes)));
     }
 }

--- a/src/main/java/io/vertx/spi/cluster/consul/impl/NodeManager.java
+++ b/src/main/java/io/vertx/spi/cluster/consul/impl/NodeManager.java
@@ -209,10 +209,10 @@ public class NodeManager {
         Future<Void> futureHaInfoCache = Future.future();
         consulClient.getValues(ClusterManagerMaps.VERTX_HA_INFO.getName(), futureMap -> {
             if (futureMap.succeeded()) {
-                if (futureMap.result().getList() != null) {
+                if (futureMap.result() != null && futureMap.result().getList() != null) {
                     futureMap.result().getList().forEach(keyValue -> {
-                        K key = (K) keyValue.getKey().replace(ClusterManagerMaps.VERTX_HA_INFO.getName() + "/", "");
                         try {
+                            K key = (K) keyValue.getKey().replace(ClusterManagerMaps.VERTX_HA_INFO.getName() + "/", "");
                             V value = Utils.decode(keyValue.getValue());
                             haInfoMap.put(key, value);
                         } catch (Exception e) {


### PR DESCRIPTION
TTL on entries is handled by relaying on consul session itself. We get  the session registered first in consul and then bound the session's id with entries we want to put ttl on. 